### PR TITLE
Removed double signing of apk file

### DIFF
--- a/lib/souyuz/generators/build_command_generator.rb
+++ b/lib/souyuz/generators/build_command_generator.rb
@@ -44,7 +44,8 @@ module Souyuz
       def targets
         targets = []
         targets += build_targets
-        targets << "-t:SignAndroidPackage" if Souyuz.project.android?
+        targets << "-t:SignAndroidPackage" if Souyuz.project.android? and !Souyuz.config[:keystore_path] and !Souyuz.config[:keystore_alias] and !Souyuz.config[:keystore_password]
+        targets << "-t:Package" if Souyuz.project.android? and Souyuz.config[:keystore_path] and Souyuz.config[:keystore_alias] and Souyuz.config[:keystore_password]
 
         targets
       end

--- a/lib/souyuz/runner.rb
+++ b/lib/souyuz/runner.rb
@@ -14,7 +14,7 @@ module Souyuz
         path
       elsif Souyuz.project.android?
         path = apk_file
-        if config[:keystore_path] && config[:keystore_alias]
+        if config[:keystore_path] && config[:keystore_alias] && config[:keystore_password]
           apksign_and_zipalign
         end
 


### PR DESCRIPTION
Added addition check for "keystore_password" before trying to sign apk

When building Xamarin.Android project with:
keystore_path
keystore_alias
keystore_password

provided, "SignAndroidPackage" target added automatically, which causing VisualStudio to build app, than sign with default Xamarin keystore, then "apksign_and_zipalign" sign it again.

This fix checking:
if keystore details are provided -> it will replace "SignAndroidPackage" with "Package" to generate apk, then "apksign_and_zipalign" sign apk with desired credentials.

if keystore details are NOT provided: "SignAndroidPackage" with be used to sign apk with Xamarin default credentials and "NO" "apksign_and_zipalign" will be called.

